### PR TITLE
Move npm scripts to bash script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "lab-es6",
   "version": "1.0.0",
+  "repository": "https://github.com/jedireza/lab-es6",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "lab -t 100 -S -T ./node_modules/lab-babel -I __core-js_shared__ ./test/src/",
-    "cover": "lab -S -T ./node_modules/lab-babel -I __core-js_shared__ -r html -o ./test/artifacts/coverage.html ./test/src/ && open ./test/artifacts/coverage.html && exit 0"
+    "test": "scripts/test",
+    "cover": "scripts/cover"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/cover
+++ b/scripts/cover
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+export NODE_ENV=test;
+
+mkdir -p ./coverage
+
+# run the tests
+lab -S -T ./node_modules/lab-babel -I __core-js_shared__ -r html -o ./test/artifacts/coverage.html ./test/src/ 
+
+# open coverage page
+open ./test/artifacts/coverage.html 
+
+# exit the coverage script
+exit 0

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+export NODE_ENV=test;
+
+# run the tests
+lab -t 100 -S -T ./node_modules/lab-babel -I __core-js_shared__ ./test/src


### PR DESCRIPTION
Just move the long lines in package.json inside scripts level to `scripts/cover`and `scripts/test` for more readable further review.
